### PR TITLE
feat: reusable GitHub Actions for Nix cache setup and push

### DIFF
--- a/.github/actions/push/action.yml
+++ b/.github/actions/push/action.yml
@@ -1,0 +1,48 @@
+name: "Push to Nix Cache"
+description: "Sign and upload store paths to nix-cache.stevedores.org"
+
+inputs:
+  paths:
+    description: "Space-separated Nix store paths or flake refs to push (e.g., .#default or /nix/store/...)"
+    required: true
+  signing-secret-key:
+    description: "Ed25519 secret key for signing (reads from /tmp/nix-sign-key if setup action was used)"
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Sign and push to cache
+      shell: bash
+      run: |
+        KEY_FILE="/tmp/nix-sign-key"
+        if [ -n "${{ inputs.signing-secret-key }}" ]; then
+          echo "${{ inputs.signing-secret-key }}" > "$KEY_FILE"
+          chmod 600 "$KEY_FILE"
+        fi
+
+        if [ ! -f "$KEY_FILE" ]; then
+          echo "::error::No signing key found. Run setup action with push=true first, or pass signing-secret-key."
+          exit 1
+        fi
+
+        for path in ${{ inputs.paths }}; do
+          echo "::group::Pushing $path"
+
+          # Resolve flake ref to store path if needed
+          if [[ "$path" == .#* ]] || [[ "$path" == *#* ]]; then
+            STORE_PATH=$(nix build "$path" --no-link --print-out-paths 2>/dev/null || echo "")
+            if [ -z "$STORE_PATH" ]; then
+              echo "::warning::Could not resolve $path — skipping"
+              echo "::endgroup::"
+              continue
+            fi
+          else
+            STORE_PATH="$path"
+          fi
+
+          nix store sign --key-file "$KEY_FILE" "$STORE_PATH"
+          nix copy --to "https://nix-cache.stevedores.org" "$STORE_PATH"
+          echo "Pushed: $STORE_PATH"
+          echo "::endgroup::"
+        done

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,46 @@
+name: "Setup Nix Cache"
+description: "Install Nix, configure nix-cache.stevedores.org substituter, and optionally push build results"
+
+inputs:
+  push:
+    description: "Push build results to cache after build (default: false)"
+    required: false
+    default: "false"
+  cache-auth-token:
+    description: "Bearer token for PUT uploads (required if push=true)"
+    required: false
+  signing-secret-key:
+    description: "Ed25519 secret key for signing store paths (required if push=true)"
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@v9
+      with:
+        extra-conf: |
+          substituters = https://cache.nixos.org https://nix-cache.stevedores.org
+          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= stevedores-cache-1:bXLxkipycRWproIJnk8pPWNFdgVfeV+I2mJXCoW4/ag=
+
+    - name: Setup signing key
+      if: inputs.push == 'true'
+      shell: bash
+      run: |
+        if [ -z "${{ inputs.signing-secret-key }}" ]; then
+          echo "::error::signing-secret-key is required when push=true"
+          exit 1
+        fi
+        if [ -z "${{ inputs.cache-auth-token }}" ]; then
+          echo "::error::cache-auth-token is required when push=true"
+          exit 1
+        fi
+        echo "${{ inputs.signing-secret-key }}" > /tmp/nix-sign-key
+        chmod 600 /tmp/nix-sign-key
+
+    - name: Configure cache upload auth
+      if: inputs.push == 'true'
+      shell: bash
+      run: |
+        mkdir -p ~/.config/nix
+        echo "machine nix-cache.stevedores.org password ${{ inputs.cache-auth-token }}" >> ~/.config/nix/netrc

--- a/README.md
+++ b/README.md
@@ -100,6 +100,43 @@ nix copy --to "http://nix-cache.stevedores.org?secret-key=/tmp/nix-sign-key" .#p
 > **Do NOT use `attic push`** — this is a plain binary cache, not an Attic server.
 > The `attic-client` devShell dependency can be removed from consuming repos.
 
+## Reusable GitHub Actions
+
+This repo provides composite actions for CI integration.
+
+### Setup (pull from cache)
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: stevedores-org/nix-cache/.github/actions/setup@develop
+        with:
+          push: ${{ github.event_name == 'push' }}
+          cache-auth-token: ${{ secrets.CACHE_AUTH_TOKEN }}
+          signing-secret-key: ${{ secrets.NIX_SIGNING_SECRET_KEY }}
+
+      - run: nix flake check
+
+      # Push build results (only on merge, when push=true was set)
+      - uses: stevedores-org/nix-cache/.github/actions/push@develop
+        if: github.event_name == 'push'
+        with:
+          paths: .#default
+```
+
+### Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| `push` | No | Enable cache uploads (default: `false`) |
+| `cache-auth-token` | If push | Bearer token for PUT auth |
+| `signing-secret-key` | If push | Ed25519 secret key for signing |
+
+All secrets are available as `stevedores-org` org-level secrets.
+
 ## API Endpoints
 
 | Endpoint | Method | Description |


### PR DESCRIPTION
## Summary
- Add `.github/actions/setup` — composite action: install Nix, configure substituter + trusted keys, set up auth for push
- Add `.github/actions/push` — composite action: sign and upload store paths or flake refs
- Update README with usage examples for consuming repos

## Usage
```yaml
- uses: stevedores-org/nix-cache/.github/actions/setup@develop
  with:
    push: true
    cache-auth-token: ${{ secrets.CACHE_AUTH_TOKEN }}
    signing-secret-key: ${{ secrets.NIX_SIGNING_SECRET_KEY }}
- run: nix build
- uses: stevedores-org/nix-cache/.github/actions/push@develop
  with:
    paths: .#default
```

## Test plan
- [ ] CI passes on this PR
- [ ] Action YAML is valid (checked via `actionlint` or manual review)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)