### PR TITLE
feat: add cache metrics and /metrics endpoint

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -29,9 +29,20 @@ function makeBucket() {
   };
 }
 
+// In-memory KV stub
+function makeKV() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    async get(key: string) { return store.get(key) || null; },
+    async put(key: string, value: string) { store.set(key, value); },
+  };
+}
+
 function makeEnv(token = "test-secret-token") {
   return {
     BUCKET: makeBucket() as unknown as R2Bucket,
+    METRICS: makeKV() as unknown as KVNamespace,
     CACHE_AUTH_TOKEN: token,
   };
 }
@@ -185,6 +196,50 @@ describe("nix-cache worker", () => {
         badEnv,
       );
       expect(res.status).toBe(500);
+    });
+  });
+
+  describe("GET /metrics", () => {
+    it("rejects unauthenticated requests", async () => {
+      const res = await worker.fetch(
+        new Request("https://nix-cache.stevedores.org/metrics"),
+        env,
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("returns counters after activity", async () => {
+      // Generate some activity: 1 hit, 1 miss, 1 put, 1 auth fail
+      await worker.fetch(new Request("https://nix-cache.stevedores.org/miss.narinfo"), env);
+      await worker.fetch(
+        new Request("https://nix-cache.stevedores.org/obj", {
+          method: "PUT", body: "data",
+          headers: { Authorization: "Bearer test-secret-token" },
+        }),
+        env,
+      );
+      await worker.fetch(new Request("https://nix-cache.stevedores.org/obj"), env);
+      await worker.fetch(
+        new Request("https://nix-cache.stevedores.org/obj", {
+          method: "PUT", body: "x",
+          headers: { Authorization: "Bearer bad" },
+        }),
+        env,
+      );
+
+      const res = await worker.fetch(
+        new Request("https://nix-cache.stevedores.org/metrics", {
+          headers: { Authorization: "Bearer test-secret-token" },
+        }),
+        env,
+      );
+      expect(res.status).toBe(200);
+      const json = await res.json() as Record<string, number>;
+      expect(json.get_hit).toBe(1);
+      expect(json.get_miss).toBe(1);
+      expect(json.put_ok).toBe(1);
+      expect(json.auth_fail).toBe(1);
+      expect(json.get_total).toBe(2);
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,21 @@
  * Implements a Nix-compatible binary cache backed by Cloudflare R2.
  * GET is public (serves .narinfo and .nar files).
  * PUT requires Bearer token authentication.
+ * /metrics returns JSON counters (authenticated).
  */
 
 export interface Env {
   BUCKET: R2Bucket;
+  METRICS: KVNamespace;
   CACHE_AUTH_TOKEN: string;
+}
+
+type MetricKey = "get_hit" | "get_miss" | "put_ok" | "auth_fail";
+
+async function incMetric(kv: KVNamespace | undefined, key: MetricKey): Promise<void> {
+  if (!kv) return;
+  const val = parseInt((await kv.get(key)) || "0", 10);
+  await kv.put(key, String(val + 1));
 }
 
 function jsonError(message: string, status: number): Response {
@@ -16,6 +26,24 @@ function jsonError(message: string, status: number): Response {
     status,
     headers: { "Content-Type": "application/json" },
   });
+}
+
+function bearerAuth(request: Request, env: Env): Response | null {
+  if (!env.CACHE_AUTH_TOKEN) {
+    return jsonError("Server misconfigured: no auth token set", 500);
+  }
+  const authHeader = request.headers.get("Authorization");
+  if (!authHeader) {
+    return jsonError("Missing Authorization header", 401);
+  }
+  const [scheme, token] = authHeader.split(" ", 2);
+  if (scheme !== "Bearer" || !token) {
+    return jsonError("Authorization must use Bearer scheme", 401);
+  }
+  if (token !== env.CACHE_AUTH_TOKEN) {
+    return jsonError("Invalid token", 403);
+  }
+  return null;
 }
 
 export default {
@@ -44,14 +72,37 @@ export default {
       });
     }
 
+    // Metrics endpoint (authenticated)
+    if (path === "/metrics") {
+      const authErr = bearerAuth(request, env);
+      if (authErr) {
+        await incMetric(env.METRICS, "auth_fail");
+        return authErr;
+      }
+
+      const keys: MetricKey[] = ["get_hit", "get_miss", "put_ok", "auth_fail"];
+      const metrics: Record<string, number> = {};
+      for (const k of keys) {
+        metrics[k] = parseInt((await env.METRICS?.get(k)) || "0", 10);
+      }
+      metrics["get_total"] = metrics["get_hit"] + metrics["get_miss"];
+
+      return new Response(JSON.stringify(metrics, null, 2), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
     // GET — public, serve from R2
     if (request.method === "GET") {
       const objectName = path.startsWith("/") ? path.slice(1) : path;
       const object = await env.BUCKET.get(objectName);
 
       if (!object) {
+        await incMetric(env.METRICS, "get_miss");
         return new Response("Not found", { status: 404 });
       }
+
+      await incMetric(env.METRICS, "get_hit");
 
       const headers = new Headers();
       object.writeHttpMetadata(headers);
@@ -68,22 +119,10 @@ export default {
 
     // PUT — requires Bearer token
     if (request.method === "PUT") {
-      if (!env.CACHE_AUTH_TOKEN) {
-        return jsonError("Server misconfigured: no auth token set", 500);
-      }
-
-      const authHeader = request.headers.get("Authorization");
-      if (!authHeader) {
-        return jsonError("Missing Authorization header", 401);
-      }
-
-      const [scheme, token] = authHeader.split(" ", 2);
-      if (scheme !== "Bearer" || !token) {
-        return jsonError("Authorization must use Bearer scheme", 401);
-      }
-
-      if (token !== env.CACHE_AUTH_TOKEN) {
-        return jsonError("Invalid token", 403);
+      const authErr = bearerAuth(request, env);
+      if (authErr) {
+        await incMetric(env.METRICS, "auth_fail");
+        return authErr;
       }
 
       const objectName = path.startsWith("/") ? path.slice(1) : path;
@@ -91,6 +130,7 @@ export default {
         httpMetadata: request.headers,
       });
 
+      await incMetric(env.METRICS, "put_ok");
       return new Response("OK", { status: 201 });
     }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -36,6 +36,13 @@ NIX_PUBLIC_KEY = "stevedores-cache-1:bXLxkipycRWproIJnk8pPWNFdgVfeV+I2mJXCoW4/ag
 #   CACHE_AUTH_TOKEN        — bearer token required for PUT uploads
 #   NIX_SIGNING_SECRET_KEY  — Ed25519 secret key for signing narinfo (org-level GH secret)
 
+# ── KV: metrics counters ─────────────────────────────────────────
+# Create namespace: bunx wrangler kv namespace create METRICS
+# The id below must be updated after creation.
+[[kv_namespaces]]
+binding = "METRICS"
+id = "3c8a120b5544498986a497e7da47b1ea"
+
 # ── R2: Nix binary cache storage (.narinfo, .nar) ───────────────
 # Create bucket: wrangler r2 bucket create nix-cache
 [[r2_buckets]]


### PR DESCRIPTION
## Summary
- Track `get_hit`, `get_miss`, `put_ok`, `auth_fail` counters in Cloudflare KV
- Add authenticated `GET /metrics` endpoint returning JSON counters
- Create METRICS KV namespace
- 13 tests (2 new for metrics)

## Test plan
- [ ] CI passes (13 tests)
- [ ] After deploy: `curl -H "Authorization: Bearer <token>" https://nix-cache.stevedores.org/metrics`

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)