### PR TITLE
perf: log cache.put failures so silent regressions surface (closes #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ bunx wrangler deploy   # ship to Cloudflare
 
 Without `UPLOAD_TOKEN`, PUT returns `503 Uploads disabled` — the cache is read-only.
 
+## Operations
+
+Tail logs (including `cache.put` failures — large bodies, transient backpressure, etc.):
+
+```bash
+bunx wrangler tail
+```
+
+A silent `cache.put` failure on a hot object turns every request into a cold R2 read forever, so log entries of the form
+`cache.put failed for <name> (size=<bytes>): <error>` are an early signal worth watching.
+
 ## Generating Cache Keys
 
 ```bash

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,8 +137,19 @@ async function handleRead(
   const response = new Response(object.body, { status, headers });
 
   // Only cache full 200 responses — partials would pollute the edge cache.
+  // Failures (body too large for cache.put, transient backpressure, …) are
+  // logged via console.error so they show up in `wrangler tail`. Without
+  // this, a put that silently fails turns every request into a cold R2 read
+  // forever with no warning.
   if (status === 200) {
-    ctx.waitUntil(cache.put(cacheKey, response.clone()));
+    ctx.waitUntil(
+      cache.put(cacheKey, response.clone()).catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(
+          `cache.put failed for ${objectName} (size=${object.size}): ${message}`,
+        );
+      }),
+    );
   }
 
   return response;


### PR DESCRIPTION
## Summary
Wraps `ctx.waitUntil(cache.put(...))` with `.catch + console.error` so failures (body exceeds the edge cache put-size limit, transient backpressure) become visible in `wrangler tail` instead of vanishing.

Closes #25.

## Why first

Smallest, lowest-risk of the five perf PRs. Lands the observability needed to measure the others (HEAD cache, Range parser, conditional GET, oversize skip).

## Diff
- `src/index.ts`: 8 added lines around the `cache.put` call.
- `README.md`: new "Operations" section with the `bunx wrangler tail` hint and the log-line format.

## Test plan
- [x] `bun run typecheck` clean.
- [ ] Deploy to staging, force a large body through (e.g. a >50MB NAR if any), watch `wrangler tail` for the new log line.
- [ ] Confirm steady-state hit path still works identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)