### PR TITLE
perf: HEAD requests check edge cache before falling back to R2 (closes #22)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,8 +70,24 @@ async function handleRead(
     return new Response("Not found", { status: 404 });
   }
 
-  // HEAD: use R2.head() — never goes through the body cache.
+  // HEAD: try the GET-shaped edge cache entry first. Hash-named content is
+  // immutable, so any GET that previously hit this URL stored a 200 with
+  // the headers a HEAD wants. Returning those headers without a body costs
+  // one cache lookup (~1ms at-edge) instead of an R2.head() round-trip
+  // (~20-50ms + Class B op).
+  //
+  // Nix substituter clients fan out many parallel HEAD probes during
+  // dependency resolution; this turns the steady-state into edge-only.
   if (request.method === "HEAD") {
+    const cacheKey = new Request(request.url, { method: "GET" });
+    const cached = await caches.default.match(cacheKey);
+    if (cached) {
+      // Headers are already complete (etag, Content-Length, Content-Type,
+      // Cache-Control, Accept-Ranges) from the original GET response.
+      return new Response(null, { status: cached.status, headers: cached.headers });
+    }
+
+    // First-time HEAD (no prior GET cached this URL): fall back to R2.
     const head = await env.BUCKET.head(objectName);
     if (!head) return new Response(null, { status: 404 });
     const headers = new Headers();


### PR DESCRIPTION
## Summary
HEAD now tries `caches.default.match(getCacheKey)` first. On a hit, returns a body-less response with the cached headers (etag, Content-Length, Content-Type, Cache-Control, Accept-Ranges) — cost ~1ms vs. 20–50ms for an R2.head() round-trip. On a miss, falls back to the original R2 path.

Closes #22.

## Why it matters
Nix substituter clients fan out many parallel HEAD probes during dependency resolution. With the previous code, every probe was an R2 metadata op. After this change, the second-and-later probes for any already-warmed hash become pure edge responses with zero R2 ops.

## Diff
- `src/index.ts`: 17-line addition in the HEAD branch of `handleRead`. Same fallback shape preserved for first-time HEADs.

## Test plan
- [x] `bun run typecheck` clean.
- [ ] Deploy to staging.
- [ ] `curl -I` a hash that has never been GET'd → 200 + correct headers (R2.head() fallback).
- [ ] `curl https://nix-cache.stevedores.org/<hash>.narinfo` (warms cache).
- [ ] `curl -I` same hash → 200 + identical headers; verify no `cf-cache-status` indicating R2 in tail logs.

## Builds on
- #27 (cache.put observability, closes #25) — recommend landing that first so we can see if any hot hash isn't actually being cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)