### PR TITLE
perf: handle suffix Range + reject multi-range with 416 (closes #23)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "nix-cache",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250101.0",
+        "@types/bun": "^1.3.14",
         "typescript": "^5.6.0",
         "wrangler": "^4.0.0",
       },
@@ -150,7 +151,13 @@
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.15", "", {}, "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -181,6 +188,8 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
         "build": "bun x wrangler deploy --dry-run",
         "deploy": "bun x wrangler deploy",
         "dev": "bun x wrangler dev",
+        "test": "bun test",
         "typecheck": "bun x tsc --noEmit"
     },
     "devDependencies": {
         "@cloudflare/workers-types": "^4.20250101.0",
+        "@types/bun": "^1.3.14",
         "typescript": "^5.6.0",
         "wrangler": "^4.0.0"
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,29 +84,32 @@ async function handleRead(
     return new Response(null, { status: 200, headers });
   }
 
-  // Parse Range header before consulting the cache — cache stores full 200s
-  // only, so any Range request must bypass it and go straight to R2 for a 206.
-  const rangeHeader = request.headers.get("range");
-  let requestedOffset: number | undefined;
-  let requestedLength: number | undefined;
+  // Parse Range header. Cache stores full 200s only, so any range form
+  // bypasses it and goes to R2 for a 206. Reject multi-range with 416
+  // (was a silent full-body 200 before); accept the suffix form
+  // `bytes=-N` (was treated as no-range, pulling the whole object).
+  const parsedRange = parseRangeHeader(request.headers.get("range"));
+  if (parsedRange?.kind === "invalid") {
+    return new Response("Range Not Satisfiable", {
+      status: 416,
+      headers: { "Accept-Ranges": "bytes" },
+    });
+  }
+
   const r2Opts: R2GetOptions = {};
-  if (rangeHeader) {
-    const m = /^bytes=(\d+)-(\d*)$/.exec(rangeHeader);
-    if (m) {
-      requestedOffset = parseInt(m[1], 10);
-      const end = m[2] ? parseInt(m[2], 10) : undefined;
-      if (end !== undefined) requestedLength = end - requestedOffset + 1;
-      r2Opts.range =
-        requestedLength !== undefined
-          ? { offset: requestedOffset, length: requestedLength }
-          : { offset: requestedOffset };
-    }
+  if (parsedRange?.kind === "prefix") {
+    r2Opts.range =
+      parsedRange.length !== undefined
+        ? { offset: parsedRange.offset, length: parsedRange.length }
+        : { offset: parsedRange.offset };
+  } else if (parsedRange?.kind === "suffix") {
+    r2Opts.range = { suffix: parsedRange.length };
   }
 
   // Edge cache: hash-named, immutable full-object GETs only.
   const cache = caches.default;
   const cacheKey = new Request(url.toString(), { method: "GET" });
-  if (requestedOffset === undefined) {
+  if (parsedRange === null) {
     const cached = await cache.match(cacheKey);
     if (cached) return cached;
   }
@@ -122,11 +125,20 @@ async function handleRead(
   headers.set("Accept-Ranges", "bytes");
 
   let status = 200;
-  if (requestedOffset !== undefined) {
-    const length = requestedLength ?? object.size - requestedOffset;
+  if (parsedRange !== null) {
+    let start: number;
+    let length: number;
+    if (parsedRange.kind === "prefix") {
+      start = parsedRange.offset;
+      length = parsedRange.length ?? object.size - start;
+    } else {
+      // suffix: clamp to size when N >= size (RFC 9110 §14.1.2)
+      length = Math.min(parsedRange.length, object.size);
+      start = object.size - length;
+    }
     headers.set(
       "Content-Range",
-      `bytes ${requestedOffset}-${requestedOffset + length - 1}/${object.size}`,
+      `bytes ${start}-${start + length - 1}/${object.size}`,
     );
     headers.set("Content-Length", String(length));
     status = 206;
@@ -199,6 +211,49 @@ function extractAuthToken(authHeader: string | null): string {
 
 function isValidPath(p: string): boolean {
   return NARINFO_RE.test(p) || NAR_RE.test(p);
+}
+
+/**
+ * Parsed shape of an HTTP Range header for a single-range read.
+ *
+ * - `prefix`     — `bytes=N-` or `bytes=N-M`. `length` undefined means "to end".
+ * - `suffix`     — `bytes=-N`. Last N bytes of the object.
+ * - `invalid`    — multi-range, inverted range, or zero-length suffix.
+ *                  Callers MUST respond with 416 Range Not Satisfiable.
+ *
+ * Returns `null` for `null` header or unrecognised malformed syntax,
+ * in which case the caller treats it as no Range header (RFC 9110 §14.2).
+ */
+export type ParsedRange =
+  | { kind: "prefix"; offset: number; length?: number }
+  | { kind: "suffix"; length: number }
+  | { kind: "invalid" };
+
+export function parseRangeHeader(header: string | null): ParsedRange | null {
+  if (!header) return null;
+
+  // Multi-range: a comma anywhere in the byte ranges. We don't support it —
+  // R2 single-range is enough for narinfo/NAR access patterns.
+  if (header.includes(",")) {
+    return { kind: "invalid" };
+  }
+
+  const suffix = /^bytes=-(\d+)$/.exec(header);
+  if (suffix) {
+    const length = parseInt(suffix[1], 10);
+    return length > 0 ? { kind: "suffix", length } : { kind: "invalid" };
+  }
+
+  const single = /^bytes=(\d+)-(\d*)$/.exec(header);
+  if (single) {
+    const offset = parseInt(single[1], 10);
+    if (!single[2]) return { kind: "prefix", offset };
+    const end = parseInt(single[2], 10);
+    if (end < offset) return { kind: "invalid" };
+    return { kind: "prefix", offset, length: end - offset + 1 };
+  }
+
+  return null; // unrecognised — caller treats as no Range
 }
 
 function setContentType(headers: Headers, path: string): void {

--- a/tests/range.test.ts
+++ b/tests/range.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseRangeHeader } from "../src/index";
+
+describe("parseRangeHeader", () => {
+  test("returns null for null / empty / missing header", () => {
+    expect(parseRangeHeader(null)).toBeNull();
+    expect(parseRangeHeader("")).toBeNull();
+  });
+
+  test("returns null for unrecognised syntax (treat as no Range)", () => {
+    expect(parseRangeHeader("bytes=abc")).toBeNull();
+    expect(parseRangeHeader("items=0-100")).toBeNull();
+    expect(parseRangeHeader("bytes=")).toBeNull();
+  });
+
+  test("prefix form bytes=N-M", () => {
+    expect(parseRangeHeader("bytes=0-99")).toEqual({
+      kind: "prefix",
+      offset: 0,
+      length: 100,
+    });
+    expect(parseRangeHeader("bytes=500-1023")).toEqual({
+      kind: "prefix",
+      offset: 500,
+      length: 524,
+    });
+  });
+
+  test("prefix form bytes=N- (open-ended)", () => {
+    expect(parseRangeHeader("bytes=0-")).toEqual({
+      kind: "prefix",
+      offset: 0,
+    });
+    expect(parseRangeHeader("bytes=12345-")).toEqual({
+      kind: "prefix",
+      offset: 12345,
+    });
+  });
+
+  test("suffix form bytes=-N (last N bytes)", () => {
+    expect(parseRangeHeader("bytes=-500")).toEqual({
+      kind: "suffix",
+      length: 500,
+    });
+    expect(parseRangeHeader("bytes=-1")).toEqual({
+      kind: "suffix",
+      length: 1,
+    });
+  });
+
+  test("inverted range (end < start) is invalid", () => {
+    expect(parseRangeHeader("bytes=100-50")).toEqual({ kind: "invalid" });
+  });
+
+  test("zero-length suffix is invalid", () => {
+    expect(parseRangeHeader("bytes=-0")).toEqual({ kind: "invalid" });
+  });
+
+  test("multi-range is invalid (416)", () => {
+    expect(parseRangeHeader("bytes=0-100,200-300")).toEqual({ kind: "invalid" });
+    expect(parseRangeHeader("bytes=0-100, 200-300")).toEqual({ kind: "invalid" });
+    expect(parseRangeHeader("bytes=0-100,-50")).toEqual({ kind: "invalid" });
+    expect(parseRangeHeader("bytes=-100,-50")).toEqual({ kind: "invalid" });
+  });
+
+  test("equal start and end is a 1-byte prefix range", () => {
+    expect(parseRangeHeader("bytes=42-42")).toEqual({
+      kind: "prefix",
+      offset: 42,
+      length: 1,
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
             "esnext"
         ],
         "types": [
-            "@cloudflare/workers-types"
+            "@cloudflare/workers-types",
+            "@types/bun"
         ],
         "strict": true,
         "esModuleInterop": true,
@@ -15,6 +16,7 @@
         "forceConsistentCasingInFileNames": true
     },
     "include": [
-        "src/**/*"
+        "src/**/*",
+        "tests/**/*"
     ]
 }


### PR DESCRIPTION
## Summary
Extract Range parsing into `parseRangeHeader` (exported) and extend it past the single-prefix form. With this change a `bytes=-500` tail probe on a 500MB NAR transfers 500 bytes from R2 instead of the full archive.

Closes #23.

## What it handles now

| Input | Before | After |
| --- | --- | --- |
| `bytes=N-M` | ✅ 206 partial | ✅ 206 partial |
| `bytes=N-` | ✅ 206 partial | ✅ 206 partial |
| **`bytes=-N` (suffix)** | ❌ silent 200 full body | ✅ 206 last N bytes via R2 `{ suffix: N }` |
| **`bytes=N-M,X-Y` (multi)** | ❌ silent 200 full body | ✅ 416 Range Not Satisfiable |
| `bytes=100-50` (inverted) | ❌ silent 200 | ✅ 416 |
| `bytes=-0` (zero suffix) | ❌ silent 200 | ✅ 416 |
| `bytes=abc` / unrecognised | 200 (RFC: ignore) | 200 (unchanged) |

Suffix length clamps to `object.size` per RFC 9110 §14.1.2 when N ≥ size — returns the whole object with `Content-Range: bytes 0-(size-1)/size`.

## Diff
- `src/index.ts`: new exported `parseRangeHeader` + `ParsedRange` type; `handleRead`'s Range handling rewritten around it.
- `tests/range.test.ts`: 9 tests covering null, malformed, prefix (both forms), suffix, multi-range, inverted, zero-suffix, and the 1-byte boundary case.
- `package.json`: `test` script (`bun test`).
- `tsconfig.json`: `tests/**/*` in `include`; `@types/bun` in `types`.
- `package.json` devDeps: `@types/bun`.

## Test plan
- [x] `bun run typecheck` clean.
- [x] `bun test` → 9 pass / 0 fail.
- [ ] After deploy: `curl -r -500 https://nix-cache.stevedores.org/nar/<hash>.nar.zst` returns 206 with `Content-Range: bytes <start>-<end>/<total>` and exactly 500 bytes.
- [ ] `curl -r 0-100,200-300 …` returns 416 (not 200).

## Related
- #27 (cache.put observability, closes #25)
- #29 (HEAD edge cache, closes #22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)