### PR TITLE
perf: skip cache.put for bodies above 50 MB + log the skip (closes #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,14 +119,16 @@ Without `UPLOAD_TOKEN`, PUT returns `503 Uploads disabled` — the cache is read
 
 ## Operations
 
-Tail logs (including `cache.put` failures — large bodies, transient backpressure, etc.):
+Tail logs cover both `cache.put` failure modes:
 
 ```bash
 bunx wrangler tail
 ```
 
-A silent `cache.put` failure on a hot object turns every request into a cold R2 read forever, so log entries of the form
-`cache.put failed for <name> (size=<bytes>): <error>` are an early signal worth watching.
+- `cache.put skipped for <name> (size=<bytes> >= limit=<limit>)` — body above `CACHE_PUT_BYTE_LIMIT` (50 MB; see `src/index.ts`). Skipped pre-flight to avoid the wasted body clone + silent reject.
+- `cache.put failed for <name> (size=<bytes>): <error>` — body under the limit, but the put rejected (transient backpressure, network blip). Either failure mode turns every subsequent request into a cold R2 read, so log entries here are an early signal worth watching.
+
+NARs above the 50 MB limit therefore read from R2 cold on every request. This is acceptable for low traffic but degrades steady-state latency at scale. The longer-term path is **Path A**: serve `/nar/*` via an R2 Custom Domain so Cloudflare's CDN caches large objects directly, taking the worker out of the egress path entirely. See [issue #24](https://github.com/stevedores-org/nix-cache/issues/24).
 
 ## Generating Cache Keys
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,14 @@ const NAR_RE = /^nar\/[0-9a-z]{52}(-[0-9a-z+._-]+)?\.nar(\.(xz|zst|bz2|br))?$/;
 
 const IMMUTABLE_CACHE = "public, max-age=31536000, immutable";
 
+// Objects this large or larger won't fit in the Cache API's per-entry body
+// limit. Putting them anyway silently fails — the put rejects after the
+// body is uploaded — and every subsequent request reads from R2 cold.
+// Skipping the put outright + logging is the smallest fix; the longer-term
+// path is to serve /nar/* via an R2 Custom Domain so the worker is out of
+// the egress path for large objects entirely (#24).
+const CACHE_PUT_BYTE_LIMIT = 50 * 1024 * 1024; // 50 MB; conservative
+
 // Per-isolate cache of the imported Ed25519 key. Cloudflare reloads the isolate
 // on secret updates and deploys, so invalidation is implicit.
 let publicKeyCache: { keyName: string; key: CryptoKey } | null = null;
@@ -145,19 +153,29 @@ async function handleRead(
   const response = new Response(object.body, { status, headers });
 
   // Only cache full 200 responses — partials would pollute the edge cache.
-  // Failures (body too large for cache.put, transient backpressure, …) are
-  // logged via console.error so they show up in `wrangler tail`. Without
-  // this, a put that silently fails turns every request into a cold R2 read
-  // forever with no warning.
+  // Two failure modes, two defences:
+  //   1. Body above the Cache API per-entry limit → skip the put outright
+  //      (the request would otherwise pay for the body clone + a wasted
+  //      background upload that silently rejects).
+  //   2. Anything below the limit that still rejects (transient backpressure,
+  //      network blips) → log via console.error so it shows up in
+  //      `wrangler tail` instead of vanishing.
+  // Path A (R2 Custom Domain for /nar/*) is the longer-term fix for (1).
   if (status === 200) {
-    ctx.waitUntil(
-      cache.put(cacheKey, response.clone()).catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        console.error(
-          `cache.put failed for ${objectName} (size=${object.size}): ${message}`,
-        );
-      }),
-    );
+    if (object.size >= CACHE_PUT_BYTE_LIMIT) {
+      console.log(
+        `cache.put skipped for ${objectName} (size=${object.size} >= limit=${CACHE_PUT_BYTE_LIMIT})`,
+      );
+    } else {
+      ctx.waitUntil(
+        cache.put(cacheKey, response.clone()).catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error(
+            `cache.put failed for ${objectName} (size=${object.size}): ${message}`,
+          );
+        }),
+      );
+    }
   }
 
   return response;


### PR DESCRIPTION
## Summary
Adds `CACHE_PUT_BYTE_LIMIT = 50 MB` and gates `ctx.waitUntil(cache.put)` on `object.size`. Above the limit, the put is skipped and a `console.log` records it:

```
cache.put skipped for <name> (size=<bytes> >= limit=<limit>)
```

Closes #24 (Path B).

## Why
Without the gate, large NARs (>50 MB) silently fail the put after the body upload completes. The request pays for the body clone + the background upload, and every subsequent request reads from R2 cold — invisibly. The gate makes the gap visible and stops the wasted work.

## Two paths from the issue, and why this is Path B
- **Path A** (recommended in the issue but operator-driven): serve `/nar/*` via an R2 Custom Domain so Cloudflare's CDN caches large objects directly. Worker stays out of the egress path. Biggest absolute win but requires DNS + Cloudflare config that's outside this PR's scope.
- **Path B** (this PR): code-only fix that lands today, makes the gap visible, and stops the silent waste. Path A remains as an operator follow-up.

The README's new "Edge cache size limit" section records the decision and points operators at Path A when they want the bigger win.

## Diff
- `src/index.ts`: new `CACHE_PUT_BYTE_LIMIT` constant, ~5 lines of gating around the `cache.put` call.
- `README.md`: new section explaining the limit, the log line format, and Path A as the follow-up.

## Test plan
- [x] `bun run typecheck` clean.
- [ ] After deploy: a known-large NAR fetch produces the `cache.put skipped` log in `bunx wrangler tail`.
- [ ] A small `.narinfo` fetch still gets cached (no skip log; second-hit served from edge).

## Related
- #27 (cache.put observability, closes #25) — pairs with this one. With #27's `.catch + console.error` and this PR's pre-flight skip, both failure modes (oversize + transient) are visible.
- #29 (HEAD edge cache, closes #22)
- #30 (Range parser, closes #23)
- #31 (Conditional GET, closes #26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)