### PR TITLE
perf: 416 + Content-Range when range past end of object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,25 @@ async function handleRead(
   }
 
   const object = await env.BUCKET.get(objectName, r2Opts);
-  if (!object) return new Response("Not found", { status: 404 });
+  if (!object) {
+    // For range requests, R2 returns null both for missing keys AND for
+    // ranges past the end of an existing object. Disambiguate via HEAD so
+    // we can return 416 with a real `Content-Range: bytes */<size>` for
+    // the latter, matching RFC 9110 §15.5.17.
+    if (parsedRange?.kind === "prefix" || parsedRange?.kind === "suffix") {
+      const head = await env.BUCKET.head(objectName);
+      if (head) {
+        return new Response("Range Not Satisfiable", {
+          status: 416,
+          headers: {
+            "Content-Range": `bytes */${head.size}`,
+            "Accept-Ranges": "bytes",
+          },
+        });
+      }
+    }
+    return new Response("Not found", { status: 404 });
+  }
 
   const headers = new Headers();
   object.writeHttpMetadata(headers);
@@ -133,22 +151,27 @@ async function handleRead(
   headers.set("Accept-Ranges", "bytes");
 
   let status = 200;
-  if (parsedRange !== null) {
-    let start: number;
-    let length: number;
-    if (parsedRange.kind === "prefix") {
-      start = parsedRange.offset;
-      length = parsedRange.length ?? object.size - start;
-    } else {
-      // suffix: clamp to size when N >= size (RFC 9110 §14.1.2)
-      length = Math.min(parsedRange.length, object.size);
-      start = object.size - length;
+  if (parsedRange?.kind === "prefix" || parsedRange?.kind === "suffix") {
+    const outcome = resolveRange(parsedRange, object.size);
+    if (outcome.kind === "unsatisfiable") {
+      // The range parsed cleanly but the object's actual size makes it
+      // unsatisfiable (e.g. `bytes=N-` with N >= size). Return 416 with
+      // `Content-Range: bytes */<size>` per RFC 9110 §15.5.17. The R2 GET
+      // we just made was the cheapest path to learning object.size (a
+      // separate HEAD would cost the same Class B op).
+      return new Response("Range Not Satisfiable", {
+        status: 416,
+        headers: {
+          "Content-Range": `bytes */${object.size}`,
+          "Accept-Ranges": "bytes",
+        },
+      });
     }
     headers.set(
       "Content-Range",
-      `bytes ${start}-${start + length - 1}/${object.size}`,
+      `bytes ${outcome.start}-${outcome.start + outcome.length - 1}/${object.size}`,
     );
-    headers.set("Content-Length", String(length));
+    headers.set("Content-Length", String(outcome.length));
     status = 206;
   } else {
     headers.set("Content-Length", String(object.size));
@@ -273,6 +296,53 @@ export function parseRangeHeader(header: string | null): ParsedRange | null {
   }
 
   return null; // unrecognised — caller treats as no Range
+}
+
+/**
+ * The two `ParsedRange` shapes that can be sent to R2 (i.e. not `invalid`).
+ * `resolveRange` accepts this narrowed type so the unsatisfiable detection
+ * is purely about size, not syntax.
+ */
+export type RangeRequest =
+  | { kind: "prefix"; offset: number; length?: number }
+  | { kind: "suffix"; length: number };
+
+/**
+ * Result of intersecting a parsed range with the object's actual size.
+ *
+ * - `satisfied`     — `start` (inclusive) + `length` resolve to bytes that
+ *                     exist in the object. The caller uses these to build
+ *                     `Content-Range` and `Content-Length`.
+ * - `unsatisfiable` — the range references bytes the object doesn't have
+ *                     (offset >= size, or zero-suffix). Caller MUST respond
+ *                     with 416 + `Content-Range: bytes * /<size>`.
+ *
+ * The end of the served byte run is `start + length - 1`. For prefix ranges
+ * whose explicit end exceeds the object, the end is clamped to `size - 1`
+ * per RFC 9110 §14.1.2. For suffix ranges where N >= size, the whole object
+ * is served.
+ */
+export type RangeOutcome =
+  | { kind: "satisfied"; start: number; length: number }
+  | { kind: "unsatisfiable" };
+
+export function resolveRange(req: RangeRequest, objectSize: number): RangeOutcome {
+  // RFC 9110 §14.1.2: a byte-range-set is satisfiable iff at least one spec
+  // identifies bytes that exist. An empty object has none.
+  if (objectSize === 0) return { kind: "unsatisfiable" };
+
+  if (req.kind === "prefix") {
+    if (req.offset >= objectSize) return { kind: "unsatisfiable" };
+    const end =
+      req.length !== undefined
+        ? Math.min(req.offset + req.length - 1, objectSize - 1)
+        : objectSize - 1;
+    return { kind: "satisfied", start: req.offset, length: end - req.offset + 1 };
+  }
+  // suffix
+  if (req.length === 0) return { kind: "unsatisfiable" };
+  const length = Math.min(req.length, objectSize);
+  return { kind: "satisfied", start: objectSize - length, length };
 }
 
 function setContentType(headers: Headers, path: string): void {

--- a/tests/range.test.ts
+++ b/tests/range.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseRangeHeader } from "../src/index";
+import { parseRangeHeader, resolveRange } from "../src/index";
 
 describe("parseRangeHeader", () => {
   test("returns null for null / empty / missing header", () => {
@@ -69,6 +69,107 @@ describe("parseRangeHeader", () => {
       kind: "prefix",
       offset: 42,
       length: 1,
+    });
+  });
+});
+
+describe("resolveRange", () => {
+  const SIZE = 1000;
+
+  // prefix: bytes=N-
+  test("prefix open-ended within size → served to end", () => {
+    expect(resolveRange({ kind: "prefix", offset: 0 }, SIZE)).toEqual({
+      kind: "satisfied",
+      start: 0,
+      length: SIZE,
+    });
+    expect(resolveRange({ kind: "prefix", offset: 500 }, SIZE)).toEqual({
+      kind: "satisfied",
+      start: 500,
+      length: 500,
+    });
+  });
+
+  test("prefix open-ended at size boundary → unsatisfiable", () => {
+    expect(resolveRange({ kind: "prefix", offset: SIZE }, SIZE)).toEqual({
+      kind: "unsatisfiable",
+    });
+    expect(resolveRange({ kind: "prefix", offset: SIZE + 1 }, SIZE)).toEqual({
+      kind: "unsatisfiable",
+    });
+  });
+
+  // prefix: bytes=N-M
+  test("prefix with length within size → served as requested", () => {
+    expect(resolveRange({ kind: "prefix", offset: 100, length: 200 }, SIZE)).toEqual({
+      kind: "satisfied",
+      start: 100,
+      length: 200,
+    });
+  });
+
+  test("prefix with length extending past size → clamped to size-1", () => {
+    // bytes=900-2000 on a 1000-byte object: serve 900-999 (100 bytes).
+    expect(resolveRange({ kind: "prefix", offset: 900, length: 1100 }, SIZE)).toEqual({
+      kind: "satisfied",
+      start: 900,
+      length: 100,
+    });
+    // bytes=0-99999: serve the whole object.
+    expect(resolveRange({ kind: "prefix", offset: 0, length: 99999 }, SIZE)).toEqual({
+      kind: "satisfied",
+      start: 0,
+      length: SIZE,
+    });
+  });
+
+  test("prefix offset == size with explicit length → unsatisfiable", () => {
+    expect(resolveRange({ kind: "prefix", offset: SIZE, length: 1 }, SIZE)).toEqual({
+      kind: "unsatisfiable",
+    });
+  });
+
+  // suffix: bytes=-N
+  test("suffix within size → served from tail", () => {
+    expect(resolveRange({ kind: "suffix", length: 500 }, SIZE)).toEqual({
+      kind: "satisfied",
+      start: 500,
+      length: 500,
+    });
+    expect(resolveRange({ kind: "suffix", length: 1 }, SIZE)).toEqual({
+      kind: "satisfied",
+      start: 999,
+      length: 1,
+    });
+  });
+
+  test("suffix N >= size → serve whole object (RFC 9110 §14.1.2)", () => {
+    expect(resolveRange({ kind: "suffix", length: SIZE }, SIZE)).toEqual({
+      kind: "satisfied",
+      start: 0,
+      length: SIZE,
+    });
+    expect(resolveRange({ kind: "suffix", length: SIZE + 5000 }, SIZE)).toEqual({
+      kind: "satisfied",
+      start: 0,
+      length: SIZE,
+    });
+  });
+
+  test("suffix N == 0 → unsatisfiable", () => {
+    expect(resolveRange({ kind: "suffix", length: 0 }, SIZE)).toEqual({
+      kind: "unsatisfiable",
+    });
+  });
+
+  // empty-object edge: RFC 9110 §14.1.2 — no byte-range-spec is satisfiable
+  // when the representation has zero bytes.
+  test("empty object → all ranges unsatisfiable", () => {
+    expect(resolveRange({ kind: "prefix", offset: 0 }, 0)).toEqual({
+      kind: "unsatisfiable",
+    });
+    expect(resolveRange({ kind: "suffix", length: 1 }, 0)).toEqual({
+      kind: "unsatisfiable",
     });
   });
 });


### PR DESCRIPTION
## Summary
Follow-up to PR #30 — addresses the gaps from the [self-review](https://github.com/stevedores-org/nix-cache/pull/30#issuecomment) without expanding scope:

1. **Closes the pre-existing offset bug.** `bytes=N-` with `N >= object.size` was silently producing a malformed `Content-Range` and a 206 status. Now returns 416 + `Content-Range: bytes */<size>` per RFC 9110 §15.5.17.
2. **Adds `Content-Range: bytes */<size>` to the post-R2 416 path.** Spec-compliant; uses the size we already learned from the R2 GET (no extra HEAD).
3. **Clamps prefix range end to size-1** when the requested end exceeds the object. `bytes=900-2000` on a 1000-byte object now correctly serves 100 bytes with `Content-Range: bytes 900-999/1000` instead of writing `bytes 900-2000/1000`.
4. **Disambiguates R2 null between "not found" and "out of range"** via a HEAD probe on the range path. Only fires when a range request gets a null back from R2.
5. **New `resolveRange` pure function** centralises the "intersect parsed range with actual size" arithmetic. 9 additional tests cover prefix-within / prefix-at-boundary / prefix-clamped / suffix-within / suffix-clamped / suffix-zero / empty-object.

## Diff
- `src/index.ts`: new `RangeRequest`, `RangeOutcome`, `resolveRange` exports + a few-line refactor of the post-R2 path in `handleRead`.
- `tests/range.test.ts`: 9 new `resolveRange` tests. 18 tests total now, all green.

## Out of scope
- Inverted range (`bytes=10-5`) still returns 416 instead of being ignored per RFC. Defensible either way; leaving the stricter behaviour.
- Input strictness (whitespace, capital `Bytes=…`) — separate concern, file an issue if a real client trips on it.
- Pre-R2 416 paths (multi-range, inverted) still omit `Content-Range` because computing it requires an extra HEAD. Comment explains; acceptable since multi-range traffic is bot/scanner-level.

## Test plan
- [x] `bun run typecheck` clean.
- [x] `bun test` → 18 pass / 0 fail.
- [ ] After deploy: `curl -r 99999999- https://nix-cache.stevedores.org/nar/<hash>.nar.zst` returns 416 with `Content-Range: bytes */<size>` (was 206 + malformed before).
- [ ] `curl -r 900-2000` on an object smaller than 2000 bytes returns 206 with `Content-Range: bytes 900-<size-1>/<size>` (was 206 + over-stated length before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)