### PR TITLE
feat(metrics): port develop's KV-backed counters into main

### DIFF
--- a/.github/actions/push/action.yml
+++ b/.github/actions/push/action.yml
@@ -1,0 +1,48 @@
+name: "Push to Nix Cache"
+description: "Sign and upload store paths to nix-cache.stevedores.org"
+
+inputs:
+  paths:
+    description: "Space-separated Nix store paths or flake refs to push (e.g., .#default or /nix/store/...)"
+    required: true
+  signing-secret-key:
+    description: "Ed25519 secret key for signing (reads from /tmp/nix-sign-key if setup action was used)"
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Sign and push to cache
+      shell: bash
+      run: |
+        KEY_FILE="/tmp/nix-sign-key"
+        if [ -n "${{ inputs.signing-secret-key }}" ]; then
+          echo "${{ inputs.signing-secret-key }}" > "$KEY_FILE"
+          chmod 600 "$KEY_FILE"
+        fi
+
+        if [ ! -f "$KEY_FILE" ]; then
+          echo "::error::No signing key found. Run setup action with push=true first, or pass signing-secret-key."
+          exit 1
+        fi
+
+        for path in ${{ inputs.paths }}; do
+          echo "::group::Pushing $path"
+
+          # Resolve flake ref to store path if needed
+          if [[ "$path" == .#* ]] || [[ "$path" == *#* ]]; then
+            STORE_PATH=$(nix build "$path" --no-link --print-out-paths 2>/dev/null || echo "")
+            if [ -z "$STORE_PATH" ]; then
+              echo "::warning::Could not resolve $path — skipping"
+              echo "::endgroup::"
+              continue
+            fi
+          else
+            STORE_PATH="$path"
+          fi
+
+          nix store sign --key-file "$KEY_FILE" "$STORE_PATH"
+          nix copy --to "https://nix-cache.stevedores.org" "$STORE_PATH"
+          echo "Pushed: $STORE_PATH"
+          echo "::endgroup::"
+        done

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,46 @@
+name: "Setup Nix Cache"
+description: "Install Nix, configure nix-cache.stevedores.org substituter, and optionally push build results"
+
+inputs:
+  push:
+    description: "Push build results to cache after build (default: false)"
+    required: false
+    default: "false"
+  cache-auth-token:
+    description: "Bearer token for PUT uploads (required if push=true)"
+    required: false
+  signing-secret-key:
+    description: "Ed25519 secret key for signing store paths (required if push=true)"
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@v9
+      with:
+        extra-conf: |
+          substituters = https://cache.nixos.org https://nix-cache.stevedores.org
+          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= stevedores-cache-1:bXLxkipycRWproIJnk8pPWNFdgVfeV+I2mJXCoW4/ag=
+
+    - name: Setup signing key
+      if: inputs.push == 'true'
+      shell: bash
+      run: |
+        if [ -z "${{ inputs.signing-secret-key }}" ]; then
+          echo "::error::signing-secret-key is required when push=true"
+          exit 1
+        fi
+        if [ -z "${{ inputs.cache-auth-token }}" ]; then
+          echo "::error::cache-auth-token is required when push=true"
+          exit 1
+        fi
+        echo "${{ inputs.signing-secret-key }}" > /tmp/nix-sign-key
+        chmod 600 /tmp/nix-sign-key
+
+    - name: Configure cache upload auth
+      if: inputs.push == 'true'
+      shell: bash
+      run: |
+        mkdir -p ~/.config/nix
+        echo "machine nix-cache.stevedores.org password ${{ inputs.cache-auth-token }}" >> ~/.config/nix/netrc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [develop, main]
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run lint
+      - run: bun run format:check
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run typecheck
+
+  test:
+    name: Integration Test
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    name: Deploy Worker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: Type Check
+        run: bunx tsc --noEmit
+
+      - name: Test
+        run: bun test
+
+      - name: Deploy to Cloudflare
+        run: bunx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.lci.toml
+++ b/.lci.toml
@@ -1,0 +1,7 @@
+# lci — Local CI configuration for stevedores-org/nix-cache
+# Mirrors .github/workflows/ci.yml
+# Run: local-ci
+
+[stages]
+# Stages to run by default (in order). Options: typecheck, lint, test, format
+default = ["typecheck", "test"]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,52 @@ This workflow ensures that all documentation and YAML workflows are robust and e
 ## Agent Pre-Commit
 
 All agents must run the repo pre-commit checks before committing changes.
+
+## HTTP API
+
+The worker exposes a small surface area:
+
+| Method | Path                | Auth     | Notes                                                          |
+| ------ | ------------------- | -------- | -------------------------------------------------------------- |
+| GET    | `/nix-cache-info`   | none     | Standard Nix cache info document.                              |
+| GET    | `/health`           | none     | Liveness probe; returns JSON `{status, cache, timestamp}`.     |
+| GET    | `/<hash>.narinfo`   | none     | Read a narinfo. Honours `If-None-Match` (304) and `Range`.     |
+| GET    | `/nar/<hash>.nar*`  | none     | Read a NAR. Range-aware.                                       |
+| HEAD   | (same as GET)       | none     | RFC 9110 §13.1.2-compliant — `If-None-Match` → 304 when matched. |
+| PUT    | `/<hash>.narinfo`   | bearer   | Upload narinfo. Verified against `NIX_PUBLIC_KEY` if set.      |
+| PUT    | `/nar/<hash>.nar*`  | bearer   | Upload NAR.                                                    |
+| GET    | `/metrics`          | bearer   | Optional KV-backed counters. See below.                        |
+
+### `/metrics`
+
+When the optional `METRICS` KV namespace is bound, the worker increments
+four eventually-consistent counters from request handlers:
+
+| Key          | Incremented on                                          |
+| ------------ | ------------------------------------------------------- |
+| `get_hit`    | Any successful read (200, 206, 304, edge-cache hits, range 416). |
+| `get_miss`   | Read for an object that does not exist in R2 (404).     |
+| `put_ok`     | Successful uploads (201).                               |
+| `auth_fail`  | `/metrics` or upload requests with missing/wrong bearer (401). |
+
+`GET /metrics` returns these as JSON plus a derived `get_total = get_hit +
+get_miss`, behind the same `UPLOAD_TOKEN` bearer auth as PUT. Without the
+KV binding the endpoint still returns 200 with all-zero counters (provided
+`UPLOAD_TOKEN` is set), and all increments are no-ops — there is no failure
+mode for operators who don't want the observability layer.
+
+To enable:
+
+```bash
+wrangler kv namespace create nix-cache-metrics
+# paste the returned id into wrangler.toml under the commented
+# [[kv_namespaces]] METRICS block, then redeploy.
+```
+
+The counters race under concurrent writes (KV `get`-then-`put`) so the
+numbers are a directional signal, not exact. For exact accounting, switch
+to Workers Analytics Engine or a Durable Object.
+
 # **Grow Without Limits — Lornuai, Inc.**
 
 ## ---

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": { "recommended": true }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 120
+  },
+  "files": {
+    "includes": ["src/**/*.ts"]
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "nix-cache",
       "devDependencies": {
+        "@biomejs/biome": "^2.4.4",
         "@cloudflare/workers-types": "^4.20250101.0",
         "@types/bun": "^1.3.14",
         "typescript": "^5.6.0",
@@ -13,6 +14,24 @@
     },
   },
   "packages": {
+    "@biomejs/biome": ["@biomejs/biome@2.4.16", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.16", "@biomejs/cli-darwin-x64": "2.4.16", "@biomejs/cli-linux-arm64": "2.4.16", "@biomejs/cli-linux-arm64-musl": "2.4.16", "@biomejs/cli-linux-x64": "2.4.16", "@biomejs/cli-linux-x64-musl": "2.4.16", "@biomejs/cli-win32-arm64": "2.4.16", "@biomejs/cli-win32-x64": "2.4.16" }, "bin": { "biome": "bin/biome" } }, "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
+
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
 
     "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],

--- a/package.json
+++ b/package.json
@@ -7,9 +7,14 @@
         "deploy": "bun x wrangler deploy",
         "dev": "bun x wrangler dev",
         "test": "bun test",
-        "typecheck": "bun x tsc --noEmit"
+        "lint": "bunx biome check src/",
+        "lint:fix": "bunx biome check --write src/",
+        "format": "bunx biome format src/",
+        "format:check": "bunx biome check --linter-enabled=false src/",
+        "typecheck": "bunx tsc --noEmit"
     },
     "devDependencies": {
+        "@biomejs/biome": "^2.4.4",
         "@cloudflare/workers-types": "^4.20250101.0",
         "@types/bun": "^1.3.14",
         "typescript": "^5.6.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,13 +4,36 @@
  * Implements a Nix-compatible binary cache backed by Cloudflare R2.
  * Serves .narinfo and .nar files with edge caching, range requests,
  * Ed25519 signature verification on uploads, and constant-time
- * token auth.
+ * token auth. Optional KV-backed counters surface at /metrics
+ * (gated by UPLOAD_TOKEN).
  */
 
 export interface Env {
   BUCKET: R2Bucket;
   UPLOAD_TOKEN?: string;
   NIX_PUBLIC_KEY?: string;
+  // Optional KV binding for hit/miss/put/auth counters. When unset, all
+  // metric increments are no-ops and /metrics returns zeros. Operators
+  // who don't want counters can simply not provision the namespace.
+  METRICS?: KVNamespace;
+}
+
+type MetricKey = "get_hit" | "get_miss" | "put_ok" | "auth_fail";
+const METRIC_KEYS: readonly MetricKey[] = ["get_hit", "get_miss", "put_ok", "auth_fail"];
+
+// Counter increment is best-effort and non-atomic — KV `get` then `put` races
+// across concurrent requests. We accept under-counting (bounded by request
+// concurrency) for cache-observability use; this is not for billing. Use
+// Workers Analytics Engine or a Durable Object if exact counts matter.
+async function incMetric(kv: KVNamespace | undefined, key: MetricKey): Promise<void> {
+  if (!kv) return;
+  try {
+    const val = parseInt((await kv.get(key)) ?? "0", 10);
+    await kv.put(key, String(val + 1));
+  } catch (err: unknown) {
+    // Don't let metric failures break request handling.
+    console.error(`incMetric(${key}) failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
 }
 
 const NIX_CACHE_INFO = "StoreDir: /nix/store\nWantMassQuery: 1\nPriority: 40\n";
@@ -55,9 +78,30 @@ export default {
       });
     }
 
+    if (path === "/metrics") {
+      // Reuses UPLOAD_TOKEN — both write paths and the observability surface
+      // belong to the deploy operator. Treating these as the same auth
+      // boundary avoids juggling a second secret. If you do want them split,
+      // add a METRICS_TOKEN env and gate the bearer check on that instead.
+      if (!env.UPLOAD_TOKEN) {
+        return new Response("Metrics disabled", { status: 503 });
+      }
+      const provided = extractAuthToken(request.headers.get("authorization"));
+      if (!provided || !constantTimeEqual(provided, env.UPLOAD_TOKEN)) {
+        ctx.waitUntil(incMetric(env.METRICS, "auth_fail"));
+        return new Response("Unauthorized", { status: 401 });
+      }
+      const counters: Record<string, number> = {};
+      for (const key of METRIC_KEYS) {
+        counters[key] = parseInt((await env.METRICS?.get(key)) ?? "0", 10);
+      }
+      counters.get_total = counters.get_hit + counters.get_miss;
+      return Response.json(counters);
+    }
+
     const method = request.method;
     if (method === "GET" || method === "HEAD") return handleRead(request, env, ctx);
-    if (method === "PUT") return handleUpload(request, env);
+    if (method === "PUT") return handleUpload(request, env, ctx);
 
     return new Response("Method not allowed", {
       status: 405,
@@ -66,15 +110,12 @@ export default {
   },
 };
 
-async function handleRead(
-  request: Request,
-  env: Env,
-  ctx: ExecutionContext,
-): Promise<Response> {
+async function handleRead(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
   const url = new URL(request.url);
   const objectName = url.pathname.slice(1);
 
   if (!isValidPath(objectName)) {
+    ctx.waitUntil(incMetric(env.METRICS, "get_miss"));
     return new Response("Not found", { status: 404 });
   }
 
@@ -87,9 +128,7 @@ async function handleRead(
     // can't use HEAD as a freshness probe — they have to issue a GET and
     // discard the body.
     const headIfNoneMatch = request.headers.get("if-none-match");
-    const headConditionalEtag = headIfNoneMatch
-      ? normalizeEtag(headIfNoneMatch)
-      : undefined;
+    const headConditionalEtag = headIfNoneMatch ? normalizeEtag(headIfNoneMatch) : undefined;
 
     const cacheKey = new Request(url.toString(), { method: "GET" });
     const cached = await caches.default.match(cacheKey);
@@ -97,6 +136,7 @@ async function handleRead(
       if (headConditionalEtag) {
         const cachedEtag = normalizeEtag(cached.headers.get("etag") ?? "");
         if (cachedEtag === headConditionalEtag) {
+          ctx.waitUntil(incMetric(env.METRICS, "get_hit"));
           return new Response(null, {
             status: 304,
             headers: {
@@ -106,13 +146,18 @@ async function handleRead(
           });
         }
       }
+      ctx.waitUntil(incMetric(env.METRICS, "get_hit"));
       return new Response(null, { status: 200, headers: cached.headers });
     }
 
     const head = await env.BUCKET.head(objectName);
-    if (!head) return new Response(null, { status: 404 });
+    if (!head) {
+      ctx.waitUntil(incMetric(env.METRICS, "get_miss"));
+      return new Response(null, { status: 404 });
+    }
 
     if (headConditionalEtag && normalizeEtag(head.httpEtag) === headConditionalEtag) {
+      ctx.waitUntil(incMetric(env.METRICS, "get_hit"));
       return new Response(null, {
         status: 304,
         headers: {
@@ -129,6 +174,7 @@ async function handleRead(
     headers.set("Cache-Control", IMMUTABLE_CACHE);
     headers.set("Content-Length", String(head.size));
     headers.set("Accept-Ranges", "bytes");
+    ctx.waitUntil(incMetric(env.METRICS, "get_hit"));
     return new Response(null, { status: 200, headers });
   }
 
@@ -155,8 +201,7 @@ async function handleRead(
   // cache miss. Warm cache hits stay on the edge path; the conditional
   // comparison is handled from the cached response headers.
   const ifNoneMatch = request.headers.get("if-none-match");
-  const conditionalEtag =
-    parsedRange === null && ifNoneMatch ? normalizeEtag(ifNoneMatch) : undefined;
+  const conditionalEtag = parsedRange === null && ifNoneMatch ? normalizeEtag(ifNoneMatch) : undefined;
   if (conditionalEtag) {
     r2Opts.onlyIf = { etagDoesNotMatch: conditionalEtag };
   }
@@ -167,6 +212,7 @@ async function handleRead(
   if (parsedRange === null) {
     const cached = await cache.match(cacheKey);
     if (cached) {
+      ctx.waitUntil(incMetric(env.METRICS, "get_hit"));
       return respondFromCache(cached, conditionalEtag);
     }
   }
@@ -179,6 +225,7 @@ async function handleRead(
     if (head) {
       // Path 1: Conditional GET matched (304).
       if (conditionalEtag && head.httpEtag === conditionalEtag) {
+        ctx.waitUntil(incMetric(env.METRICS, "get_hit"));
         return new Response(null, {
           status: 304,
           headers: {
@@ -189,9 +236,11 @@ async function handleRead(
       }
       // Path 2: Range request was out of bounds (416).
       if (parsedRange?.kind === "prefix" || parsedRange?.kind === "suffix") {
+        ctx.waitUntil(incMetric(env.METRICS, "get_hit"));
         return rangeNotSatisfiable(head.size);
       }
     }
+    ctx.waitUntil(incMetric(env.METRICS, "get_miss"));
     return new Response("Not found", { status: 404 });
   }
 
@@ -206,12 +255,10 @@ async function handleRead(
   if (parsedRange?.kind === "prefix" || parsedRange?.kind === "suffix") {
     const outcome = resolveRange(parsedRange, object.size);
     if (outcome.kind === "unsatisfiable") {
+      ctx.waitUntil(incMetric(env.METRICS, "get_hit"));
       return rangeNotSatisfiable(object.size);
     }
-    headers.set(
-      "Content-Range",
-      `bytes ${outcome.start}-${outcome.start + outcome.length - 1}/${object.size}`,
-    );
+    headers.set("Content-Range", `bytes ${outcome.start}-${outcome.start + outcome.length - 1}/${object.size}`);
     headers.set("Content-Length", String(outcome.length));
     status = 206;
   } else {
@@ -219,6 +266,7 @@ async function handleRead(
   }
 
   const response = new Response(object.body, { status, headers });
+  ctx.waitUntil(incMetric(env.METRICS, "get_hit"));
 
   // Only cache full 200 responses — partials would pollute the edge cache.
   // Two failure modes, two defences:
@@ -231,16 +279,12 @@ async function handleRead(
   // Path A (R2 Custom Domain for /nar/*) is the longer-term fix for (1).
   if (status === 200) {
     if (object.size >= CACHE_PUT_BYTE_LIMIT) {
-      console.log(
-        `cache.put skipped for ${objectName} (size=${object.size} >= limit=${CACHE_PUT_BYTE_LIMIT})`,
-      );
+      console.log(`cache.put skipped for ${objectName} (size=${object.size} >= limit=${CACHE_PUT_BYTE_LIMIT})`);
     } else {
       ctx.waitUntil(
         cache.put(cacheKey, response.clone()).catch((err: unknown) => {
           const message = err instanceof Error ? err.message : String(err);
-          console.error(
-            `cache.put failed for ${objectName} (size=${object.size}): ${message}`,
-          );
+          console.error(`cache.put failed for ${objectName} (size=${object.size}): ${message}`);
         }),
       );
     }
@@ -249,13 +293,14 @@ async function handleRead(
   return response;
 }
 
-async function handleUpload(request: Request, env: Env): Promise<Response> {
+async function handleUpload(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
   if (!env.UPLOAD_TOKEN) {
     return new Response("Uploads disabled", { status: 503 });
   }
 
   const provided = extractAuthToken(request.headers.get("authorization"));
   if (!provided || !constantTimeEqual(provided, env.UPLOAD_TOKEN)) {
+    ctx.waitUntil(incMetric(env.METRICS, "auth_fail"));
     return new Response("Unauthorized", { status: 401 });
   }
 
@@ -284,6 +329,7 @@ async function handleUpload(request: Request, env: Env): Promise<Response> {
     await env.BUCKET.put(objectName, request.body, { httpMetadata });
   }
 
+  ctx.waitUntil(incMetric(env.METRICS, "put_ok"));
   return new Response("OK", { status: 201 });
 }
 
@@ -376,9 +422,7 @@ export function parseRangeHeader(header: string | null): ParsedRange | null {
  * `resolveRange` accepts this narrowed type so the unsatisfiable detection
  * is purely about size, not syntax.
  */
-export type RangeRequest =
-  | { kind: "prefix"; offset: number; length?: number }
-  | { kind: "suffix"; length: number };
+export type RangeRequest = { kind: "prefix"; offset: number; length?: number } | { kind: "suffix"; length: number };
 
 /**
  * Result of intersecting a parsed range with the object's actual size.
@@ -395,9 +439,7 @@ export type RangeRequest =
  * per RFC 9110 §14.1.2. For suffix ranges where N >= size, the whole object
  * is served.
  */
-export type RangeOutcome =
-  | { kind: "satisfied"; start: number; length: number }
-  | { kind: "unsatisfiable" };
+export type RangeOutcome = { kind: "satisfied"; start: number; length: number } | { kind: "unsatisfiable" };
 
 export function resolveRange(req: RangeRequest, objectSize: number): RangeOutcome {
   // RFC 9110 §14.1.2: a byte-range-set is satisfiable iff at least one spec
@@ -406,10 +448,7 @@ export function resolveRange(req: RangeRequest, objectSize: number): RangeOutcom
 
   if (req.kind === "prefix") {
     if (req.offset >= objectSize) return { kind: "unsatisfiable" };
-    const end =
-      req.length !== undefined
-        ? Math.min(req.offset + req.length - 1, objectSize - 1)
-        : objectSize - 1;
+    const end = req.length !== undefined ? Math.min(req.offset + req.length - 1, objectSize - 1) : objectSize - 1;
     return { kind: "satisfied", start: req.offset, length: end - req.offset + 1 };
   }
   // suffix
@@ -474,13 +513,7 @@ async function verifyNarinfo(text: string, nixPublicKey: string): Promise<boolea
       return false;
     }
     if (raw.length !== 32) return false;
-    const key = await crypto.subtle.importKey(
-      "raw",
-      raw,
-      { name: "Ed25519" },
-      false,
-      ["verify"],
-    );
+    const key = await crypto.subtle.importKey("raw", raw, { name: "Ed25519" }, false, ["verify"]);
     publicKeyCache = { keyName, key };
   }
 
@@ -514,12 +547,7 @@ async function verifyNarinfo(text: string, nixPublicKey: string): Promise<boolea
     } catch {
       continue;
     }
-    const ok = await crypto.subtle.verify(
-      { name: "Ed25519" },
-      publicKeyCache.key,
-      sigBytes,
-      fingerprintBytes,
-    );
+    const ok = await crypto.subtle.verify({ name: "Ed25519" }, publicKeyCache.key, sigBytes, fingerprintBytes);
     if (ok) return true;
   }
   return false;

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -1,0 +1,170 @@
+// Verifies the /metrics endpoint and the four KV-backed counters
+// (get_hit, get_miss, put_ok, auth_fail). The worker treats the KV binding as
+// optional — these tests wire a tiny in-memory stub and assert the worker
+// reads/writes the expected keys through the auth-gated /metrics route.
+
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+beforeAll(() => {
+  if (typeof (globalThis as any).caches === "undefined") {
+    const store = new Map<string, Response>();
+    const keyOf = (req: Request | string) =>
+      typeof req === "string" ? req : req.url;
+    (globalThis as any).caches = {
+      default: {
+        async match(req: Request | string): Promise<Response | undefined> {
+          const r = store.get(keyOf(req));
+          return r ? r.clone() : undefined;
+        },
+        async put(req: Request | string, res: Response): Promise<void> {
+          store.set(keyOf(req), res.clone());
+        },
+        async delete(req: Request | string): Promise<boolean> {
+          return store.delete(keyOf(req));
+        },
+      },
+    };
+  }
+});
+
+import worker, { type Env } from "../src/index";
+
+class StubKV {
+  store = new Map<string, string>();
+  async get(key: string): Promise<string | null> {
+    return this.store.get(key) ?? null;
+  }
+  async put(key: string, value: string): Promise<void> {
+    this.store.set(key, value);
+  }
+}
+
+class EmptyR2 {
+  async head(): Promise<null> {
+    return null;
+  }
+  async get(): Promise<null> {
+    return null;
+  }
+  async put(): Promise<unknown> {
+    throw new Error("not used");
+  }
+}
+
+const UPLOAD_TOKEN = "s3cret-test-token";
+
+function makeEnv(opts: { metrics?: boolean; token?: boolean } = {}): {
+  env: Env;
+  kv?: StubKV;
+} {
+  const kv = opts.metrics === false ? undefined : new StubKV();
+  const env: Env = {
+    BUCKET: new EmptyR2() as unknown as R2Bucket,
+    METRICS: kv as unknown as KVNamespace | undefined,
+    UPLOAD_TOKEN: opts.token === false ? undefined : UPLOAD_TOKEN,
+  };
+  return { env, kv };
+}
+
+// The worker schedules counter increments via ctx.waitUntil. The test ctx
+// collects those promises and exposes a `flush()` so assertions can wait for
+// the KV writes to settle before reading them back.
+function makeCtx(): { ctx: ExecutionContext; flush: () => Promise<void> } {
+  const pending: Promise<unknown>[] = [];
+  const ctx = {
+    waitUntil: (p: Promise<unknown>) => {
+      pending.push(p);
+    },
+    passThroughOnException: () => {},
+  } as unknown as ExecutionContext;
+  return {
+    ctx,
+    flush: async () => {
+      while (pending.length) {
+        await Promise.allSettled(pending.splice(0, pending.length));
+      }
+    },
+  };
+}
+
+function metricsReq(token?: string): Request {
+  const headers: Record<string, string> = {};
+  if (token !== undefined) headers.authorization = `Bearer ${token}`;
+  return new Request("https://nix-cache.stevedores.org/metrics", {
+    method: "GET",
+    headers,
+  });
+}
+
+describe("/metrics endpoint", () => {
+  test("503 when UPLOAD_TOKEN is unset (metrics gated by the same secret)", async () => {
+    const { env } = makeEnv({ token: false });
+    const { ctx } = makeCtx();
+    const res = await worker.fetch(metricsReq(UPLOAD_TOKEN), env, ctx);
+    expect(res.status).toBe(503);
+  });
+
+  test("401 with no bearer; increments auth_fail", async () => {
+    const { env, kv } = makeEnv();
+    const { ctx, flush } = makeCtx();
+    const res = await worker.fetch(metricsReq(), env, ctx);
+    expect(res.status).toBe(401);
+    await flush();
+    expect(kv?.store.get("auth_fail")).toBe("1");
+  });
+
+  test("401 with wrong bearer; increments auth_fail", async () => {
+    const { env, kv } = makeEnv();
+    const { ctx, flush } = makeCtx();
+    const res = await worker.fetch(metricsReq("not-the-token"), env, ctx);
+    expect(res.status).toBe(401);
+    await flush();
+    expect(kv?.store.get("auth_fail")).toBe("1");
+  });
+
+  test("200 with valid bearer returns counters JSON (zeros when KV is empty)", async () => {
+    const { env } = makeEnv();
+    const { ctx } = makeCtx();
+    const res = await worker.fetch(metricsReq(UPLOAD_TOKEN), env, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      get_hit: 0,
+      get_miss: 0,
+      put_ok: 0,
+      auth_fail: 0,
+      get_total: 0,
+    });
+  });
+
+  test("GET on a missing object increments get_miss and surfaces in /metrics", async () => {
+    const { env, kv } = makeEnv();
+    const { ctx, flush } = makeCtx();
+    const missing = new Request(
+      "https://nix-cache.stevedores.org/00000000000000000000000000000099.narinfo",
+      { method: "GET" },
+    );
+    const res = await worker.fetch(missing, env, ctx);
+    expect(res.status).toBe(404);
+    await flush();
+    expect(kv?.store.get("get_miss")).toBe("1");
+
+    const m = await worker.fetch(metricsReq(UPLOAD_TOKEN), env, ctx);
+    const body = (await m.json()) as Record<string, number>;
+    expect(body.get_miss).toBe(1);
+    expect(body.get_total).toBe(1);
+  });
+
+  test("KV binding absent → /metrics still gated by token, counters all zero", async () => {
+    const { env } = makeEnv({ metrics: false });
+    const { ctx } = makeCtx();
+    const res = await worker.fetch(metricsReq(UPLOAD_TOKEN), env, ctx);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, number>;
+    expect(body.get_hit).toBe(0);
+    expect(body.get_miss).toBe(0);
+    expect(body.put_ok).toBe(0);
+    expect(body.auth_fail).toBe(0);
+    expect(body.get_total).toBe(0);
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,7 +14,17 @@ enabled = true
 binding = "BUCKET"
 bucket_name = "nix-cache"
 
+# Optional KV namespace for hit/miss/put/auth counters surfaced at GET /metrics.
+# Provision once with `wrangler kv namespace create nix-cache-metrics`, then
+# uncomment and paste the returned id. With the binding absent, all metric
+# increments are no-ops and /metrics returns 503 (because UPLOAD_TOKEN gates
+# it). The counters are best-effort — KV writes are eventually consistent and
+# failures are logged but never propagated to the client request.
+# [[kv_namespaces]]
+# binding = "METRICS"
+# id      = "REPLACE_ME"
+
 # Secrets (set via `wrangler secret put`):
-#   UPLOAD_TOKEN     — required to enable PUT uploads
+#   UPLOAD_TOKEN     — required to enable PUT uploads and to authenticate /metrics reads
 #   NIX_PUBLIC_KEY   — optional; when set, narinfo uploads must carry a valid Ed25519 signature
 #                      (format: "keyname:base64-32-byte-pubkey")


### PR DESCRIPTION
## Summary

Reconciles the develop/main divergence flagged in #37. Brings develop's metrics surface, CI scaffolding, and formatting baseline into main's single-file Worker shape (no Durable Objects, no scheduled handler — main stays the simpler runtime).

- New `/metrics` endpoint (GET, bearer-auth) backed by an **optional** `METRICS` KV namespace. When the binding is absent, all metric increments are no-ops and `/metrics` returns 200 with zeros (provided `UPLOAD_TOKEN` is set). Operators who don't want observability can simply not provision the namespace.
- Four counters wired at every terminal return path: `get_hit`, `get_miss`, `put_ok`, `auth_fail`. Reads are classified by whether R2 produced data; the `/metrics` JSON also includes a derived `get_total`.
- `handleUpload` now takes `ctx` so 401/201 paths can `waitUntil` their counter writes.
- 6-case test file (`tests/metrics.test.ts`) covering 503/401/200, KV-absent fallback, and a real GET-miss → `/metrics` round trip. All 34 existing tests still pass.
- Scaffolding ported from develop: `.github/workflows/{ci,deploy}.yml`, `.github/actions/{setup,push}/action.yml`, `biome.json`, `.lci.toml`, develop's `package.json` lint/format/typecheck scripts.
- Worker formatted by `biome --write src/`.
- README: a focused "HTTP API" table + `/metrics` section sit on top of the existing org-wide boilerplate.

## What's **not** in this PR

- develop's deletions of `CLAUDE.md` / `AGENTS.md` / the 6-File Rule scaffolding. Those are org-wide policy files; their removal belongs in a separate, scoped PR — not bundled with the metrics surface.
- The `head-conditional.test.ts` regression was retained (develop had removed it). The RFC 9110 §13.1.2 fix in #36 needs the coverage.

## Counter semantics (important)

KV `get`-then-`put` is **not atomic**. Under concurrent writes the counters race and will under-count. This is acceptable for cache observability (it's a directional signal, not billing). For exact accounting, switch to Workers Analytics Engine or a Durable Object — documented in the README.

## Test plan

- [x] `bun test` — 34 pass (28 prior + 6 new)
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check src/` — no errors (4 infos for narinfo bracket-access; left as-is)
- [ ] Manual: deploy to a scratch worker, hit `/` then `/metrics` with bearer, expect `get_hit=1, get_miss=0`. Defer to merge.
- [ ] Operator step (post-merge): `wrangler kv namespace create nix-cache-metrics`, paste id into `wrangler.toml`, redeploy. Optional — skip if you don't want counters.

Refs: #37