### PR TITLE
fix(read): conditional GET with matching If-None-Match returns 304, not 404

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -260,8 +260,11 @@ async function handleRead(request: Request, env: Env, ctx: ExecutionContext): Pr
     // OR if the onlyIf condition failed. Disambiguate via HEAD.
     const head = await env.BUCKET.head(objectName);
     if (head) {
-      // Path 1: Conditional GET matched (304).
-      if (conditionalEtag && head.httpEtag === conditionalEtag) {
+      // Path 1: Conditional GET matched (304). `head.httpEtag` is quoted but
+      // `conditionalEtag` is normalized (unquoted), so normalize before
+      // comparing — mirrors the HEAD path above. Without this, a matching
+      // conditional GET fell through to 404 instead of 304.
+      if (conditionalEtag && normalizeEtag(head.httpEtag) === conditionalEtag) {
         return new Response(null, {
           status: 304,
           headers: {

--- a/tests/get-conditional.test.ts
+++ b/tests/get-conditional.test.ts
@@ -1,0 +1,113 @@
+// Regression test for: GET with `If-None-Match` was returning 404 instead of
+// 304 when the etag matched. The R2 `onlyIf: { etagDoesNotMatch }` makes
+// `BUCKET.get` return null on a match; the worker then heads the object to
+// disambiguate 304 vs 404/416. It compared the quoted `head.httpEtag` against
+// the normalized (unquoted) `conditionalEtag`, so the 304 branch never fired
+// and the request fell through to 404. Mirrors tests/head-conditional.test.ts.
+
+import { beforeAll, describe, expect, test } from "bun:test";
+
+beforeAll(() => {
+  if (typeof (globalThis as any).caches === "undefined") {
+    const store = new Map<string, Response>();
+    const keyOf = (req: Request | string) =>
+      typeof req === "string" ? req : req.url;
+    (globalThis as any).caches = {
+      default: {
+        async match(req: Request | string): Promise<Response | undefined> {
+          const r = store.get(keyOf(req));
+          return r ? r.clone() : undefined;
+        },
+        async put(req: Request | string, res: Response): Promise<void> {
+          store.set(keyOf(req), res.clone());
+        },
+        async delete(req: Request | string): Promise<boolean> {
+          return store.delete(keyOf(req));
+        },
+      },
+    };
+  }
+});
+
+import worker, { type Env } from "../src/index";
+
+class StubR2Object {
+  constructor(
+    private bodyBytes: Uint8Array,
+    public httpEtag: string,
+  ) {}
+  get size() {
+    return this.bodyBytes.length;
+  }
+  get body(): ReadableStream<Uint8Array> {
+    return new ReadableStream({
+      start: (controller) => {
+        controller.enqueue(this.bodyBytes);
+        controller.close();
+      },
+    });
+  }
+  writeHttpMetadata(_h: Headers): void {}
+}
+
+class StubR2Bucket {
+  static readonly KEY = "00000000000000000000000000000001.narinfo";
+  static readonly ETAG = '"deadbeefdeadbeefdeadbeefdeadbeef"';
+  static readonly BODY = "StorePath: /nix/store/abc\n";
+
+  async head(name: string): Promise<StubR2Object | null> {
+    if (name !== StubR2Bucket.KEY) return null;
+    return new StubR2Object(new TextEncoder().encode(StubR2Bucket.BODY), StubR2Bucket.ETAG);
+  }
+  async get(name: string, opts?: any): Promise<StubR2Object | null> {
+    if (name !== StubR2Bucket.KEY) return null;
+    if (opts?.onlyIf?.etagDoesNotMatch) {
+      const want = opts.onlyIf.etagDoesNotMatch;
+      const haveUnquoted = StubR2Bucket.ETAG.replace(/^"|"$/g, "");
+      if (haveUnquoted === want) return null; // condition failed → R2 returns null
+    }
+    return new StubR2Object(new TextEncoder().encode(StubR2Bucket.BODY), StubR2Bucket.ETAG);
+  }
+  async put(): Promise<unknown> {
+    throw new Error("PUT not used in this test");
+  }
+}
+
+const env: Env = { BUCKET: new StubR2Bucket() as unknown as R2Bucket };
+const ctx = { waitUntil: () => {} } as unknown as ExecutionContext;
+
+function getReq(ifNoneMatch?: string): Request {
+  const headers: Record<string, string> = {};
+  if (ifNoneMatch !== undefined) headers["if-none-match"] = ifNoneMatch;
+  return new Request(`https://nix-cache.stevedores.org/${StubR2Bucket.KEY}`, {
+    method: "GET",
+    headers,
+  });
+}
+
+describe("GET conditional", () => {
+  test("GET with matching If-None-Match returns 304 (was 404)", async () => {
+    const res = await worker.fetch(getReq(StubR2Bucket.ETAG), env, ctx);
+    expect(res.status).toBe(304);
+    expect(res.headers.get("etag")).toBe(StubR2Bucket.ETAG);
+    expect(await res.text()).toBe("");
+  });
+
+  test("GET with weak validator W/ matching variant also returns 304", async () => {
+    const res = await worker.fetch(getReq(`W/${StubR2Bucket.ETAG}`), env, ctx);
+    expect(res.status).toBe(304);
+  });
+
+  test("GET with non-matching If-None-Match returns 200 with body", async () => {
+    const res = await worker.fetch(getReq('"someothertag"'), env, ctx);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("etag")).toBe(StubR2Bucket.ETAG);
+    expect(await res.text()).toBe(StubR2Bucket.BODY);
+  });
+
+  test("GET without If-None-Match returns 200 with body", async () => {
+    const res = await worker.fetch(getReq(), env, ctx);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(StubR2Bucket.BODY);
+  });
+});


### PR DESCRIPTION
## Bug (ffb)

`handleRead` forwards `If-None-Match` to R2 as `onlyIf: { etagDoesNotMatch }`. On a match, R2 `get` returns `null`, so the worker `head`s the object to disambiguate 304 vs 404/416. That branch compared the **quoted** `head.httpEtag` against the **normalized (unquoted)** `conditionalEtag`:

```ts
if (conditionalEtag && head.httpEtag === conditionalEtag) {  // '"abc"' === 'abc' → never true
```

So a conditional GET whose `If-None-Match` **matched** fell through to **404** instead of **304 Not Modified** — breaking client revalidation (a Nix client could read it as the path having disappeared).

The HEAD path (`normalizeEtag(head.httpEtag) === headConditionalEtag`) was already correct and had a regression test; the GET path had neither.

## Fix
- Normalize `head.httpEtag` before the comparison, mirroring the HEAD path.
- Add `tests/get-conditional.test.ts` (matching INM → 304, weak validator → 304, non-matching → 200+body, no INM → 200+body).

## Verification
- `bun test` → 78 pass / 0 fail (4 new).
- `bunx tsc --noEmit` clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>